### PR TITLE
Enable pdf

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -57,7 +57,7 @@
       "Pdf"
     ]
   },
-  "need_generate_pdf_url_template": false,
+  "need_generate_pdf_url_template": true,
   "need_generate_intellisense": false,
   "Targets": {
     "Pdf": {


### PR DESCRIPTION
# Les contributions publiques ne sont pas acceptées pour le moment

Ce référentiel a été rendu public pour faciliter le téléchargement et l'utilisation de ce contenu pour créer des solutions d'aide personnalisées.
Nous n'acceptons pas les contributions publiques à ce référentiel ou à ce contenu pour le moment.
Si vous souhaitez contribuer au contenu publié par Microsoft, accédez au référentiel pour la version anglaise, où les contributions publiques sont traitées.
